### PR TITLE
Revised Card stagechange route

### DIFF
--- a/Server/models/Card.js
+++ b/Server/models/Card.js
@@ -100,7 +100,8 @@ var cardSchema = new mongoose.Schema({
     },
     load:{
         type: Number, 
-        required: true
+        required: true,
+        default: 1
     },
     currentStage:{
         type: String, 

--- a/Server/models/Card.js
+++ b/Server/models/Card.js
@@ -22,8 +22,7 @@ var stageSchema = new mongoose.Schema({
     },
     endDate:{
         type: Date, 
-        required: false,
-        default: null
+        required: false
     }
 });
 stageSchema.plugin(immutablePlugin);
@@ -101,8 +100,7 @@ var cardSchema = new mongoose.Schema({
     },
     load:{
         type: Number, 
-        required: true, 
-        default: 1
+        required: true
     },
     currentStage:{
         type: String, 

--- a/Server/routes/api/card.js
+++ b/Server/routes/api/card.js
@@ -342,17 +342,16 @@ router.put('/stagechange', async function (req, res){
 
     // Create the next stage and push it into the Card.stage array with an endDate of null.
     // If the next stage is "DONE", set an end date.
+    // The startDate of the new stage is set in the Card model.
     if(`${req.body.stageName}`.toUpperCase() == "DONE"){
         await card.stage.push({
             'stageName':req.body.stageName,
-            'startDate':Date.now(),
             'endDate':Date.now()
         });
     }
     else{
         await card.stage.push({
             'stageName':req.body.stageName,
-            'startDate':Date.now(),
             'endDate':null
         });
     }


### PR DESCRIPTION
Refactored the api/stagechange route:

1) Removed the find condition card.stage.endDate == null.  
- This introduced a potential point of failure if the endDate was saved but the next stage was not inserted into the card.stage array.  
- Instead, the card of interest is first found, the INDEX of the LAST ENTRY in the card.stage array is found.
- The LAST STAGE endDate is UPDATED by the card.stage[lastIndex]._id value.
This will always work.

2) If the NEW STAGE is 'DONE' the endDate of the new stage needs to be set to Date.now, not null.  This was coded as a conditional statement on the structure of the new stage to push to the card.stage array.
ALSO this required a change to the Card.js model to remove the default endDate value of null.  